### PR TITLE
Remove unsound code and unsafe APIs

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,5 +1,3 @@
-
-
 struct Foo(String);
 
 fn main() {

--- a/src/Arc.rs
+++ b/src/Arc.rs
@@ -1,84 +1,47 @@
-use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Weak};
 
 #[derive(Debug)]
 pub struct SharedPtr<T: ?Sized> {
-    rc: MaybeUninit<Arc<T>>,
+    rc: Option<Arc<T>>,
 }
-
-unsafe impl<T: ?Sized + Sync + Send> Send for SharedPtr<T> {}
-unsafe impl<T: ?Sized + Sync + Send> Sync for SharedPtr<T> {}
 
 impl<T> SharedPtr<T> {
     #[inline]
     pub fn new(v: T) -> SharedPtr<T> {
         SharedPtr {
-            rc: MaybeUninit::new(Arc::new(v)),
+            rc: Some(Arc::new(v)),
         }
     }
     #[inline]
     pub fn write(&mut self, v: T) {
-        if self.is_null() {
-            self.rc.write(Arc::new(v));
-        } else {
-            unsafe {
-                self.rc.assume_init_drop();
-                self.rc.write(Arc::new(v));
-            }
-        }
+        self.rc = Some(Arc::new(v));
     }
     #[inline]
     pub fn assume_init(self) -> Option<Arc<T>> {
-        if self.is_null() {
-            None
-        } else {
-            unsafe { Some(std::mem::transmute::<Self, Arc<T>>(self)) }
-        }
+        self.rc
     }
 }
 impl<T: ?Sized> SharedPtr<T> {
     #[inline]
     pub fn zeroed() -> SharedPtr<T> {
-        SharedPtr {
-            rc: MaybeUninit::zeroed(),
-        }
+        SharedPtr { rc: None }
     }
     #[inline]
     pub fn is_null(&self) -> bool {
-        let p = self.rc.as_ptr() as *const usize;
-        unsafe { p.read() == 0 }
+        self.rc.is_none()
     }
     #[inline]
     pub fn set_null(&mut self) {
-        unsafe {
-            if !self.is_null() {
-                self.rc.assume_init_drop();
-                self.rc = MaybeUninit::zeroed();
-            }
-        }
+        self.rc = None;
     }
     #[inline]
     pub fn weak(&self) -> Option<Weak<T>> {
-        if !self.is_null() {
-            Some(Arc::downgrade(self))
-        } else {
-            None
-        }
+        self.rc.as_ref().map(Arc::downgrade)
     }
-    ///# Safety
     #[inline]
-    pub unsafe fn get_mut_ref(&self) -> &mut T {
-        &mut *(self.as_ref() as *const T as *mut T)
-    }
-}
-
-impl<T: ?Sized> Drop for SharedPtr<T> {
-    #[inline]
-    fn drop(&mut self) {
-        if !self.is_null() {
-            unsafe { self.rc.assume_init_drop() }
-        }
+    pub fn get_mut_ref(&mut self) -> &mut T {
+        Arc::get_mut(&mut *self).expect("shared get_mut_ref")
     }
 }
 
@@ -86,42 +49,22 @@ impl<T: ?Sized> Deref for SharedPtr<T> {
     type Target = Arc<T>;
     #[inline]
     fn deref(&self) -> &Self::Target {
-        unsafe {
-            if self.is_null() {
-                panic!("null shared deref")
-            }
-
-            self.rc.assume_init_ref()
-        }
+        self.rc.as_ref().expect("null shared deref")
     }
 }
 
 impl<T: ?Sized> DerefMut for SharedPtr<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe {
-            if self.is_null() {
-                panic!("null shared deref mut")
-            }
-
-            self.rc.assume_init_mut()
-        }
+        self.rc.as_mut().expect("null shared deref mut")
     }
 }
 
 impl<T: ?Sized> Clone for SharedPtr<T> {
     #[inline]
     fn clone(&self) -> Self {
-        unsafe {
-            if !self.is_null() {
-                let rc = self.rc.assume_init_ref().clone();
-                let may = MaybeUninit::<Arc<T>>::new(rc);
-                SharedPtr { rc: may }
-            } else {
-                SharedPtr {
-                    rc: MaybeUninit::<Arc<T>>::zeroed(),
-                }
-            }
+        Self {
+            rc: self.rc.clone(),
         }
     }
 }
@@ -129,11 +72,7 @@ impl<T: ?Sized> Clone for SharedPtr<T> {
 impl<T: ?Sized> From<Arc<T>> for SharedPtr<T> {
     #[inline]
     fn from(r: Arc<T>) -> Self {
-        unsafe {
-            let ptr = &r as *const Arc<T> as *const SharedPtr<T>;
-            std::mem::forget(r);
-            ptr.read()
-        }
+        Self { rc: Some(r) }
     }
 }
 
@@ -142,4 +81,12 @@ impl<T: ?Sized> Default for SharedPtr<T> {
     fn default() -> Self {
         SharedPtr::<T>::zeroed()
     }
+}
+
+#[test]
+fn assert_send_sync() {
+    fn asserts<T: Send + Sync>() {}
+
+    asserts::<SharedPtr<u32>>();
+    asserts::<SharedPtr<str>>();
 }

--- a/src/Rc.rs
+++ b/src/Rc.rs
@@ -1,83 +1,49 @@
-use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
 use std::rc::{Rc, Weak};
 
 #[derive(Debug)]
 pub struct SharedPtr<T: ?Sized> {
-    rc: MaybeUninit<Rc<T>>,
+    rc: Option<Rc<T>>,
 }
 
 impl<T> SharedPtr<T> {
     #[inline]
     pub fn new(v: T) -> SharedPtr<T> {
         SharedPtr {
-            rc: MaybeUninit::new(Rc::new(v)),
+            rc: Some(Rc::new(v)),
         }
     }
     #[inline]
     pub fn write(&mut self, v: T) {
-        if self.is_null() {
-            self.rc.write(Rc::new(v));
-        } else {
-            unsafe {
-                self.rc.assume_init_drop();
-                self.rc.write(Rc::new(v));
-            }
-        }
+        self.rc = Some(Rc::new(v));
     }
     #[inline]
     pub fn assume_init(self) -> Option<Rc<T>> {
-        if self.is_null() {
-            None
-        } else {
-            unsafe { Some(std::mem::transmute::<Self, Rc<T>>(self)) }
-        }
+        self.rc
     }
 }
 
 impl<T: ?Sized> SharedPtr<T> {
     #[inline]
     pub fn zeroed() -> SharedPtr<T> {
-        SharedPtr {
-            rc: MaybeUninit::zeroed(),
-        }
+        SharedPtr { rc: None }
     }
 
     #[inline]
     pub fn weak(&self) -> Option<Weak<T>> {
-        if !self.is_null() {
-            Some(Rc::downgrade(self))
-        } else {
-            None
-        }
+        self.rc.as_ref().map(Rc::downgrade)
     }
     #[inline]
     pub fn set_null(&mut self) {
-        unsafe {
-            if !self.is_null() {
-                self.rc.assume_init_drop();
-                self.rc = MaybeUninit::zeroed();
-            }
-        }
+        self.rc = None;
     }
     #[inline]
     pub fn is_null(&self) -> bool {
-        let p = self.rc.as_ptr() as *const usize;
-        unsafe { p.read() == 0 }
+        self.rc.is_none()
     }
-    ///# Safety
     #[inline]
-    pub unsafe fn get_mut_ref(&self) -> &mut T {
-        &mut *(self.as_ref() as *const T as *mut T)
-    }
-}
-
-impl<T: ?Sized> Drop for SharedPtr<T> {
-    #[inline]
-    fn drop(&mut self) {
-        if !self.is_null() {
-            unsafe { self.rc.assume_init_drop() }
-        }
+    pub fn get_mut_ref(&mut self) -> &mut T {
+        Rc::get_mut(&mut *self).expect("shared get_mut_ref")
     }
 }
 
@@ -85,42 +51,22 @@ impl<T: ?Sized> Deref for SharedPtr<T> {
     type Target = Rc<T>;
     #[inline]
     fn deref(&self) -> &Self::Target {
-        unsafe {
-            if self.is_null() {
-                panic!("null shared deref")
-            }
-
-            self.rc.assume_init_ref()
-        }
+        self.rc.as_ref().expect("null shared deref")
     }
 }
 
 impl<T: ?Sized> DerefMut for SharedPtr<T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe {
-            if self.is_null() {
-                panic!("null shared deref mut")
-            }
-
-            self.rc.assume_init_mut()
-        }
+        self.rc.as_mut().expect("null shared deref mut")
     }
 }
 
 impl<T: ?Sized> Clone for SharedPtr<T> {
     #[inline]
     fn clone(&self) -> Self {
-        unsafe {
-            if !self.is_null() {
-                let rc = self.rc.assume_init_ref().clone();
-                let may = MaybeUninit::<Rc<T>>::new(rc);
-                SharedPtr { rc: may }
-            } else {
-                SharedPtr {
-                    rc: MaybeUninit::<Rc<T>>::zeroed(),
-                }
-            }
+        Self {
+            rc: self.rc.clone(),
         }
     }
 }
@@ -128,11 +74,7 @@ impl<T: ?Sized> Clone for SharedPtr<T> {
 impl<T: ?Sized> From<Rc<T>> for SharedPtr<T> {
     #[inline]
     fn from(r: Rc<T>) -> Self {
-        unsafe {
-            let ptr = &r as *const Rc<T> as *const SharedPtr<T>;
-            std::mem::forget(r);
-            ptr.read()
-        }
+        Self { rc: Some(r) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
-#![feature(maybe_uninit_extra)]
-#![feature(maybe_uninit_ref)]
-#![feature(unsize)]
-#![feature(dispatch_from_dyn)]
 #![allow(non_snake_case)]
+#![forbid(unsafe_code)]
 
 pub mod Arc;
 pub mod Rc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,22 +4,21 @@
 #![feature(dispatch_from_dyn)]
 #![allow(non_snake_case)]
 
-pub mod Rc;
 pub mod Arc;
+pub mod Rc;
 
-
-pub trait ISetNullWeak{
+pub trait ISetNullWeak {
     fn set_null(&mut self);
 }
 
-impl <T> ISetNullWeak for std::rc::Weak<T>{
+impl<T> ISetNullWeak for std::rc::Weak<T> {
     fn set_null(&mut self) {
-        *self=Default::default();
+        *self = Default::default();
     }
 }
 
-impl <T> ISetNullWeak for std::sync::Weak<T>{
+impl<T> ISetNullWeak for std::sync::Weak<T> {
     fn set_null(&mut self) {
-        *self=Default::default();
+        *self = Default::default();
     }
 }


### PR DESCRIPTION
Fixes: #1

I also ran rustfmt on the code so that formatting would be made consistent - only pay attention to the second commit since the first is just formatting changes.